### PR TITLE
Feature/support as-at date for dmf hit

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,9 @@ thanks goes to the management at Clarity Services Inc. for allowing this code to
 * Just instantiate the object with an SSN.
     ssn = SsnValidator::Ssn.new('123-45-6789')
 
+* Can also pass optional validation date, so you can see if the SSN would have been on the DMF file as at that date. Defaults to today.
+    ssn = SsnValidator::Ssn.new('123-45-6789', '2006-01-01')
+
 * Then check if it's valid
     ssn.valid?
     ssn.death_master_file_hit?

--- a/test/test_ssn_validator.rb
+++ b/test/test_ssn_validator.rb
@@ -82,4 +82,25 @@ class TestSsnValidator < Test::Unit::TestCase
     assert !validator.death_master_file_hit?
   end
 
+  def test_death_master_file_hit_with_validation_date
+    create_death_master_file_table
+    DeathMasterFileLoader.new(File.dirname(__FILE__) + '/files/test_dmf_initial_load.txt','2009-01-01').load_file
+
+    ssn = SsnValidator::Ssn.new('666781978', (Date.today - 5))
+    assert_equal (Date.today - 5), ssn.validation_date
+
+    ssn = SsnValidator::Ssn.new('666781978', (Date.today - 5).to_s)
+    assert_equal (Date.today - 5), ssn.validation_date
+
+    ssn = SsnValidator::Ssn.new('666781978', 'not a date')
+    assert_equal Date.today, ssn.validation_date
+
+    validator = SsnValidator::Ssn.new('772781978', '2008-01-01') # ssn from file with DMF date 2009
+    assert !validator.death_master_file_hit?
+
+    validator = SsnValidator::Ssn.new('666781978', '2011-01-01') # ssn not in file
+    assert_nil validator.death_master_file_record
+    assert !validator.death_master_file_hit?
+  end
+
 end


### PR DESCRIPTION
Hi Kevin,

Analytics asked if we could support the social_security_deceased flag in Inquiry for retros. I added the feature to your gem. Can you review it and perhaps bump your gem version? Thanks heaps!    Jim.
