### PR TITLE
Update ssn_high_group_code_loader.rb

### DIFF
--- a/app/models/ssn_high_group_code_loader.rb
+++ b/app/models/ssn_high_group_code_loader.rb
@@ -65,7 +65,7 @@ class SsnHighGroupCodeLoader
 
   #extract the date from the file in the format mm/dd/yy
   def self.extract_as_of_date(text)
-    as_of_start_index = text =~ /\d\d\/\d\d\/\d\d/
+    as_of_start_index = text =~ /\d?\d\/\d\d\/\d\d/
     Date.strptime($&, '%m/%d/%y') unless as_of_start_index.nil?
   end
 


### PR DESCRIPTION
Modify date-matching regex to handle dates without a leading zero.

Is it still necessary or useful to run the high_group_loader rake task, since the SSA has implemented randomized assignment?  If yes, it looks like their website started documenting dates with no leading zero in January of '07, like 1/03/07.  The single-character change in this pull request handles that case.

If no longer necessary, perhaps it would be good to update the README.

Thanks!
